### PR TITLE
Implement radial dead zones

### DIFF
--- a/ds4wizard-cpp/AxisOptions.cpp
+++ b/ds4wizard-cpp/AxisOptions.cpp
@@ -1,5 +1,7 @@
 #include "pch.h"
 #include "AxisOptions.h"
+#include "Vector2.h"
+#include "Vector3.h"
 
 AxisOptions::AxisOptions(AxisPolarity polarity)
 	: polarity(polarity)
@@ -47,40 +49,78 @@ InputAxisOptions::InputAxisOptions(AxisPolarity polarity)
 {
 }
 
-void InputAxisOptions::applyDeadZone(float& analog) const
+bool InputAxisOptions::exceedsDeadZone(float value) const
 {
-	const auto dzValue = deadZone.value_or(0.0f);
+	return value >= deadZone.value_or(0.0f);
+}
 
-	switch (deadZoneMode.value_or(DeadZoneMode::scale))
+float InputAxisOptions::applyToValueWithMagnitude(float axisValue, float axisVectorMagnitude) const
+{
+	switch (deadZoneSource.value_or(DeadZoneSource::axisVectorMagnitude))
 	{
-		case DeadZoneMode::hardLimit:
-			analog = analog >= dzValue ? analog : 0.0f;
-			break;
+		case +DeadZoneSource::none:
+			return applyToValue(axisValue);
 
-		case DeadZoneMode::scale:
-			analog = std::max(0.0f, (analog - dzValue) / (1.0f - dzValue));
-			break;
+		case +DeadZoneSource::axisVectorMagnitude:
+			if (exceedsDeadZone(axisVectorMagnitude))
+			{
+				// if our target axis is the one in the vector that pushed the magnitude
+				// over the threshold, the dead-zone'd magnitude will *always* be less
+				// than the raw value. for other axes in the vector, it will *always* be
+				// greater, thus allowing axisValue through instead.
+				return std::min(applyToValue(axisVectorMagnitude), axisValue);
+			}
+
+			return 0.0f;
+
+		case +DeadZoneSource::axisValue:
+			if (exceedsDeadZone(axisValue))
+			{
+				return applyToValue(axisValue);
+			}
+
+			return 0.0f;
 
 		default:
-			throw std::out_of_range("invalid DeadZoneMode");
+			throw std::out_of_range("invalid DeadZoneSource");
 	}
+}
+
+float InputAxisOptions::applyToValue(float value) const
+{
+	const auto dzValue = deadZone.value_or(0.0f);
+	value = std::max(0.0f, (value - dzValue) / (1.0f - dzValue));
 
 	if (invert.value_or(false))
 	{
-		analog = 1.0f - analog;
+		value = 1.0f - value;
 	}
 
 	if (multiplier.has_value())
 	{
-		analog *= multiplier.value();
+		value *= multiplier.value();
 	}
+
+	return value;
+}
+
+float InputAxisOptions::applyToValue(float axisValue, const Vector2& axisVector) const
+{
+	const float vectorMagnitude = (axisVector.normalized() * std::min(1.0f, axisVector.length())).length();
+	return applyToValueWithMagnitude(axisValue, vectorMagnitude);
+}
+
+float InputAxisOptions::applyToValue(float axisValue, const Vector3& axisVector) const
+{
+	const float vectorMagnitude = (axisVector.normalized() * std::min(1.0f, axisVector.length())).length();
+	return applyToValueWithMagnitude(axisValue, vectorMagnitude);
 }
 
 bool InputAxisOptions::operator==(const InputAxisOptions& other) const
 {
 	return AxisOptions::operator==(other)
 	       && invert == other.invert
-	       && deadZoneMode == other.deadZoneMode
+	       && deadZoneSource == other.deadZoneSource
 	       && deadZone == other.deadZone;
 }
 
@@ -98,9 +138,9 @@ void InputAxisOptions::readJson(const nlohmann::json& json)
 		invert = json["invert"].get<bool>();
 	}
 
-	if (json.find("deadZoneMode") != json.end())
+	if (json.find("deadZoneSource") != json.end())
 	{
-		deadZoneMode = DeadZoneMode::_from_string(json.value("deadZoneMode", "scale").c_str());
+		deadZoneSource = DeadZoneSource::_from_string(json.value("deadZoneSource", "axisVectorMagnitude").c_str());
 	}
 
 	if (json.find("deadZone") != json.end())
@@ -118,9 +158,9 @@ void InputAxisOptions::writeJson(nlohmann::json& json) const
 		json["invert"] = invert.value();
 	}
 
-	if (deadZoneMode.has_value())
+	if (deadZoneSource.has_value())
 	{
-		json["deadZoneMode"] = deadZoneMode.value()._to_string();
+		json["deadZoneSource"] = deadZoneSource.value()._to_string();
 	}
 
 	if (deadZone.has_value())

--- a/ds4wizard-cpp/AxisOptions.cpp
+++ b/ds4wizard-cpp/AxisOptions.cpp
@@ -89,7 +89,7 @@ float InputAxisOptions::applyToValueWithMagnitude(float axisValue, float axisVec
 float InputAxisOptions::applyToValue(float value) const
 {
 	const auto dzValue = deadZone.value_or(0.0f);
-	value = std::max(0.0f, (value - dzValue) / (1.0f - dzValue));
+	value = std::clamp((value - dzValue) / (1.0f - dzValue), 0.0f, 1.0f);
 
 	if (invert.value_or(false))
 	{

--- a/ds4wizard-cpp/AxisOptions.h
+++ b/ds4wizard-cpp/AxisOptions.h
@@ -51,8 +51,6 @@ public:
 	 */
 	std::optional<bool> invert;
 
-	// TODO: /!\ /!\ /!\ (issue #1) implement radial dead zone
-
 	/**
 	 * \brief The dead zone mode to use if configured.
 	 * If \c DeadZoneSource::none or \c std::nullopt, no

--- a/ds4wizard-cpp/AxisOptions.h
+++ b/ds4wizard-cpp/AxisOptions.h
@@ -4,6 +4,9 @@
 #include "JsonData.h"
 #include <optional>
 
+class Vector3;
+class Vector2;
+
 /**
  * \brief Common configuration for an axis.
  */
@@ -52,15 +55,15 @@ public:
 
 	/**
 	 * \brief The dead zone mode to use if configured.
-	 * If \c DeadZoneMode::none or \c std::nullopt, no
+	 * If \c DeadZoneSource::none or \c std::nullopt, no
 	 * dead zone will be applied to the axis.
-	 * \sa DeadZoneMode, deadZone
+	 * \sa DeadZoneSource, deadZone
 	 */
-	std::optional<DeadZoneMode> deadZoneMode;
+	std::optional<DeadZoneSource> deadZoneSource;
 
 	/**
 	 * \brief Dead zone threshold.
-	 * \sa deadZoneMode
+	 * \sa deadZoneSource
 	 */
 	std::optional<float> deadZone;
 
@@ -74,12 +77,57 @@ public:
 	 */
 	explicit InputAxisOptions(AxisPolarity polarity);
 
+private:
 	/**
-	 * \brief Applies the dead zone formula configured by \c deadZoneMode to a given value.
-	 * \param analog The value to apply the formula to.
-	 * \sa deadZoneMode
+	 * \brief Check if \a value exceeds configured dead zone, if any.
 	 */
-	void applyDeadZone(float& analog) const;
+	[[nodiscard]] bool exceedsDeadZone(float value) const;
+
+	/**
+	 * \brief Returns the provided analog input with the stored multiplier, inverse, and dead zone applied.
+	 * 
+	 * If \c deadZoneSource is \c DeadZoneSource::axisVectorMagnitude, \a axisVectorMagnitude is used for activation,
+	 * and \a axisValue is returned only with options applied (i.e. without dead zone scaling applied).
+	 *
+	 * Otherwise, \a axisVector is returned with options and dead zone scaling applied.
+	 */
+	[[nodiscard]] float applyToValueWithMagnitude(float axisValue, float axisVectorMagnitude) const;
+
+public:
+	/**
+	 * \brief Returns the value with multiplier, inverse, and dead zone applied.
+	 */
+	[[nodiscard]] float applyToValue(float value) const;
+
+	/**
+	 * \brief Returns the provided analog input with the stored multiplier, inverse, and dead zone applied.
+	 * 
+	 * If \c deadZoneSource is \c DeadZoneSource::axisVectorMagnitude, the magnitude
+	 * of \a axisVector is used for activation, and \a axisValue is returned only with options
+	 * applied (i.e. without dead zone scaling applied).
+	 *
+	 * Otherwise, \a axisVector is returned with options and dead zone scaling applied.
+	 * 
+	 * \param axisValue The raw axis value provided by the device, clamped according to polarity.
+	 * \param axisVector The vector that the axis value belongs to.
+	 * \return The analog value with options applied.
+	 */
+	[[nodiscard]] float applyToValue(float axisValue, const Vector2& axisVector) const;
+
+	/**
+	 * \brief Returns the provided analog input with the stored multiplier, inverse, and dead zone applied.
+	 *
+	 * If \c deadZoneSource is \c DeadZoneSource::axisVectorMagnitude, the magnitude
+	 * of \a axisVector is used for activation, and \a axisValue is returned only with options
+	 * applied (i.e. without dead zone scaling applied).
+	 *
+	 * Otherwise, \a axisVector is returned with options and dead zone scaling applied.
+	 *
+	 * \param axisValue The raw axis value provided by the device, clamped according to polarity.
+	 * \param axisVector The vector that the axis value belongs to.
+	 * \return The analog value with options applied.
+	 */
+	[[nodiscard]] float applyToValue(float axisValue, const Vector3& axisVector) const;
 
 	bool operator==(const InputAxisOptions& other) const;
 	bool operator!=(const InputAxisOptions& other) const;
@@ -114,7 +162,7 @@ public:
 	 * \param axis The axis to retrieve the configuration for.
 	 * \return The configuration for the requested axis, or empty configuration if not found.
 	 */
-	AxisOptions getAxisOptions(XInputAxis::T axis) const;
+	[[nodiscard]] AxisOptions getAxisOptions(XInputAxis::T axis) const;
 
 	bool operator==(const XInputAxes& other) const;
 	bool operator!=(const XInputAxes& other) const;

--- a/ds4wizard-cpp/AxisOptions.h
+++ b/ds4wizard-cpp/AxisOptions.h
@@ -81,6 +81,8 @@ private:
 	 */
 	[[nodiscard]] bool exceedsDeadZone(float value) const;
 
+public:
+	// TODO: better documentation - i.e. axisValue is returned as-is sometimes
 	/**
 	 * \brief Returns the provided analog input with the stored multiplier, inverse, and dead zone applied.
 	 * 
@@ -91,7 +93,6 @@ private:
 	 */
 	[[nodiscard]] float applyToValueWithMagnitude(float axisValue, float axisVectorMagnitude) const;
 
-public:
 	/**
 	 * \brief Returns the value with multiplier, inverse, and dead zone applied.
 	 */

--- a/ds4wizard-cpp/Ds4DeviceManager.cpp
+++ b/ds4wizard-cpp/Ds4DeviceManager.cpp
@@ -226,7 +226,7 @@ void Ds4DeviceManager::registerDeviceCallbacks(const std::wstring& serialString,
 				break;
 		}
 	};
-	
+
 	token_store.push_back(device->onConnect.add(onConnect));
 	token_store.push_back(device->onConnectFailure.add(onConnect));
 	token_store.push_back(device->onDisconnect.add(onDisconnect));

--- a/ds4wizard-cpp/Ds4Input.h
+++ b/ds4wizard-cpp/Ds4Input.h
@@ -65,10 +65,10 @@ public:
 	/**
 	 * \brief Get the magnitude of an axis.
 	 * \param axis The axis to retrieve.
-	 * \param polarity The desired polarity of the axis.
+	 * \param polarity The desired polarity of the axis, or \c std::nullopt for both positive and negative.
 	 * \return The magnitude of the axis. If it does not align with the desired \a polarity, \c 0.0f is returned.
 	 */
-	float getAxis(Ds4Axes_t axis, const std::optional<AxisPolarity>& polarity) const;
+	[[nodiscard]] float getAxis(Ds4Axes_t axis, const std::optional<AxisPolarity>& polarity) const;
 
 private:
 	Ds4Buttons_t lastHeldButtons = 0;

--- a/ds4wizard-cpp/Ds4TouchRegion.cpp
+++ b/ds4wizard-cpp/Ds4TouchRegion.cpp
@@ -385,7 +385,7 @@ float Ds4TouchRegion::getDeadZone(Direction_t direction)
 	return touchAxisOptions[direction].deadZone.value_or(0.0f);
 }
 
-// UNDONE: update to be more like InputaxisOptions::applyToValue
+// UNDONE: update to be more like InputAxisOptions::applyToValue
 float Ds4TouchRegion::applyDeadZone(Direction_t direction, float value) const
 {
 	const auto it = touchAxisOptions.find(direction);

--- a/ds4wizard-cpp/Ds4TouchRegion.cpp
+++ b/ds4wizard-cpp/Ds4TouchRegion.cpp
@@ -172,7 +172,7 @@ bool Ds4TouchRegion::isActive(Ds4Buttons_t sender, Direction_t direction) const
 			}
 
 			float axis = getSimulatedAxis(sender, direction);
-			applyDeadZone(direction, axis);
+			axis = applyDeadZone(direction, axis);
 			return !gmath::is_zero(axis);
 		}
 
@@ -385,17 +385,18 @@ float Ds4TouchRegion::getDeadZone(Direction_t direction)
 	return touchAxisOptions[direction].deadZone.value_or(0.0f);
 }
 
-void Ds4TouchRegion::applyDeadZone(Direction_t direction, float& analog) const
+// UNDONE: update to be more like InputaxisOptions::applyToValue
+float Ds4TouchRegion::applyDeadZone(Direction_t direction, float value) const
 {
 	const auto it = touchAxisOptions.find(direction);
 
 	if (it == touchAxisOptions.end())
 	{
-		return;
+		return value;
 	}
 	
 	const InputAxisOptions& options = it->second;
-	options.applyDeadZone(analog);
+	return options.applyToValue(value);
 }
 
 bool Ds4TouchRegion::operator==(const Ds4TouchRegion& other) const

--- a/ds4wizard-cpp/Ds4TouchRegion.cpp
+++ b/ds4wizard-cpp/Ds4TouchRegion.cpp
@@ -1,5 +1,7 @@
 #include "pch.h"
 #include "Ds4TouchRegion.h"
+#include "InputSimulator.h"
+#include "ISimulator.h"
 
 ISimulator* Ds4TouchRegion::getSimulator(InputSimulator* parent)
 {
@@ -159,20 +161,20 @@ bool Ds4TouchRegion::isActive(Ds4Buttons_t sender, Direction_t direction) const
 		case Ds4TouchRegionType::stickAutoCenter:
 		case Ds4TouchRegionType::trackball:
 		{
-			if (direction == Direction::none)
+			// FIXME: do we really want this for an axis?
+			/*if (direction == Direction::none)
 			{
 				return isTouchActive(sender);
-			}
+			}*/
 
-			const auto simulatorState = getSimulatorState();
+			const std::optional<PressedState> simulatorState = getSimulatorState();
 
 			if (simulatorState.has_value() && !Pressable::isActiveState(*simulatorState))
 			{
 				return false;
 			}
 
-			float axis = getSimulatedAxis(sender, direction);
-			axis = applyDeadZone(direction, axis);
+			const float axis = getSimulatedAxisWithOptionsApplied(sender, direction);
 			return !gmath::is_zero(axis);
 		}
 
@@ -242,21 +244,32 @@ float Ds4TouchRegion::getSimulatedAxis(Ds4Buttons_t sender, Direction_t directio
 		point = points2.newest().point;
 	}
 
+	auto getVectorLength = [this, sender]() -> float
+	{
+		Vector2 axis(-getSimulatedAxis(sender, Direction::up)   + getSimulatedAxis(sender, Direction::down),
+		             -getSimulatedAxis(sender, Direction::left) + getSimulatedAxis(sender, Direction::right));
+
+		const float length = std::min(axis.length(), 1.0f);
+		axis.normalize();
+		return (axis * length).length();
+	};
+
 	short x = std::clamp(point.x, left, right);
 	short y = std::clamp(point.y, top, bottom);
+
 	float result;
 
 	switch (type)
 	{
 		case +Ds4TouchRegionType::stickAutoCenter:
 		{
-			Ds4Vector2 start = getStartPoint(sender);
+			const Ds4Vector2 start = getStartPoint(sender);
 
-			int width  = std::max(start.x - left, right - start.x);
-			int height = std::max(start.y - top, bottom - start.y);
+			const int width  = std::max(start.x - left, right - start.x);
+			const int height = std::max(start.y - top, bottom - start.y);
 
-			short sx = start.x;
-			short sy = start.y;
+			const short sx = start.x;
+			const short sy = start.y;
 
 			switch (direction)
 			{
@@ -276,6 +289,10 @@ float Ds4TouchRegion::getSimulatedAxis(Ds4Buttons_t sender, Direction_t directio
 					result = std::clamp(std::clamp(x - sx, -width, width) / static_cast<float>(width), 0.0f, 1.0f);
 					break;
 
+				case Direction::none:
+					result = getVectorLength();
+					break;
+
 				default:
 					throw std::runtime_error("invalid Direction");
 			}
@@ -287,7 +304,7 @@ float Ds4TouchRegion::getSimulatedAxis(Ds4Buttons_t sender, Direction_t directio
 		{
 			const Vector2 normalized = trackball->velocity.normalized();
 			const float length = trackball->velocity.length();
-			const auto factor = trackball->settings.ballSpeed;
+			const float factor = trackball->settings.ballSpeed;
 
 			switch (direction)
 			{
@@ -323,11 +340,11 @@ float Ds4TouchRegion::getSimulatedAxis(Ds4Buttons_t sender, Direction_t directio
 			x = static_cast<short>(x - left);
 			y = static_cast<short>(y - top);
 
-			int width  = right - left;
-			int height = bottom - top;
+			const int width  = right - left;
+			const int height = bottom - top;
 
-			int cx = width / 2;
-			int cy = height / 2;
+			const int cx = width / 2;
+			const int cy = height / 2;
 
 			switch (direction)
 			{
@@ -347,6 +364,10 @@ float Ds4TouchRegion::getSimulatedAxis(Ds4Buttons_t sender, Direction_t directio
 					result = std::clamp(std::clamp(x - cx, -width, width) / static_cast<float>(cx), 0.0f, 1.0f);
 					break;
 
+				case Direction::none:
+					result = getVectorLength();
+					break;
+
 				default:
 					throw std::runtime_error("invalid Direction");
 			}
@@ -355,6 +376,21 @@ float Ds4TouchRegion::getSimulatedAxis(Ds4Buttons_t sender, Direction_t directio
 	}
 
 	return result;
+}
+
+float Ds4TouchRegion::getSimulatedAxisWithOptionsApplied(Ds4Buttons_t sender, Direction_t direction) const
+{
+	const float value = getSimulatedAxis(sender, direction);
+	const auto it = touchAxisOptions.find(direction);
+
+	if (it == touchAxisOptions.end())
+	{
+		return value;
+	}
+
+	const float magnitude = getSimulatedAxis(sender, Direction::none);
+	const InputAxisOptions& options = it->second;
+	return options.applyToValueWithMagnitude(value, magnitude);
 }
 
 const decltype(Ds4TouchRegion::points1)& Ds4TouchRegion::getPoints(Ds4Buttons_t sender) const
@@ -370,33 +406,6 @@ const decltype(Ds4TouchRegion::points1)& Ds4TouchRegion::getPoints(Ds4Buttons_t 
 	}
 
 	throw;
-}
-
-// HACK: why does this just provide the dead zone? Why doesn't it do its own simulation?
-float Ds4TouchRegion::getDeadZone(Direction_t direction)
-{
-	const auto it = touchAxisOptions.find(direction);
-
-	if (it == touchAxisOptions.end())
-	{
-		return 0.0f;
-	}
-
-	return touchAxisOptions[direction].deadZone.value_or(0.0f);
-}
-
-// UNDONE: update to be more like InputAxisOptions::applyToValue
-float Ds4TouchRegion::applyDeadZone(Direction_t direction, float value) const
-{
-	const auto it = touchAxisOptions.find(direction);
-
-	if (it == touchAxisOptions.end())
-	{
-		return value;
-	}
-	
-	const InputAxisOptions& options = it->second;
-	return options.applyToValue(value);
 }
 
 bool Ds4TouchRegion::operator==(const Ds4TouchRegion& other) const

--- a/ds4wizard-cpp/Ds4TouchRegion.h
+++ b/ds4wizard-cpp/Ds4TouchRegion.h
@@ -225,14 +225,14 @@ public:
 	 * \param direction The direction of touch movement.
 	 * \return The dead zone of the specified direction.
 	 */
-	float getDeadZone(Direction_t direction);
+	[[nodiscard]] float getDeadZone(Direction_t direction);
 
 	/**
 	 * \brief Apply the configured dead zone formula of a direction to an analog value.
 	 * \param direction The direction of touch movement.
-	 * \param analog The value to apply the dead zone formula to.
+	 * \param value The value to apply the dead zone formula to.
 	 */
-	void applyDeadZone(Direction_t direction, float& analog) const;
+	[[nodiscard]] float applyDeadZone(Direction_t direction, float value) const;
 
 	bool operator==(const Ds4TouchRegion& other) const;
 	bool operator!=(const Ds4TouchRegion& other) const;

--- a/ds4wizard-cpp/Ds4TouchRegion.h
+++ b/ds4wizard-cpp/Ds4TouchRegion.h
@@ -66,6 +66,9 @@ struct Ds4TouchHistory
 	Ds4TouchHistory() = default;
 };
 
+class InputSimulator;
+class ISimulator;
+
 // TODO: /!\ just let the region pull the touch data on its own!
 
 /**
@@ -86,10 +89,9 @@ class Ds4TouchRegion : public JsonData
 	circular_buffer<Ds4TouchHistory, 30> points1 {}, points2 {};
 
 	std::shared_ptr<TrackballSimulator> trackball;
-
-public:
 	std::shared_ptr<TrackballSettings> trackballSettings;
 
+public:
 	/**
 	 * \brief Pressed state for multi-touch point 1.
 	 * \sa Pressable
@@ -210,6 +212,8 @@ public:
 	 */
 	void deactivateTouch(Ds4Buttons_t sender, Ds4Vector2 point);
 
+	// TODO: fix documentation for getSimulatedAxis/etc, as it is not always a touch delta that is returned.
+
 	/**
 	 * \brief Get the delta of the activation point and current touch coordinates.
 	 * \param sender The multi-touch sender (touch 1, touch 2).
@@ -218,21 +222,16 @@ public:
 	 */
 	[[nodiscard]] float getSimulatedAxis(Ds4Buttons_t sender, Direction_t direction) const;
 
+	/**
+	 * \brief Get the simulated axis for the given touch activator and requested direction.
+	 * \param sender The multi-touch sender (touch 1, touch 2).
+	 * \param direction The direction of touch movement.
+	 * \return The delta between the start point and \a point.
+	 */
+	[[nodiscard]] float getSimulatedAxisWithOptionsApplied(Ds4Buttons_t sender, Direction_t direction) const;
+
+	// UNDONE: nice documentation, nerd!
 	[[nodiscard]] const decltype(points1)& getPoints(Ds4Buttons_t sender) const;
-
-	/**
-	 * \brief Get the dead zone of the specified touch direction.
-	 * \param direction The direction of touch movement.
-	 * \return The dead zone of the specified direction.
-	 */
-	[[nodiscard]] float getDeadZone(Direction_t direction);
-
-	/**
-	 * \brief Apply the configured dead zone formula of a direction to an analog value.
-	 * \param direction The direction of touch movement.
-	 * \param value The value to apply the dead zone formula to.
-	 */
-	[[nodiscard]] float applyDeadZone(Direction_t direction, float value) const;
 
 	bool operator==(const Ds4TouchRegion& other) const;
 	bool operator!=(const Ds4TouchRegion& other) const;

--- a/ds4wizard-cpp/InputSimulator.cpp
+++ b/ds4wizard-cpp/InputSimulator.cpp
@@ -312,7 +312,7 @@ void InputSimulator::runMap(const InputMap& m, InputModifier const* modifier)
 			{
 				Ds4TouchRegion* region = touchRegions[m.inputTouchRegion];
 
-				if (region->type == +Ds4TouchRegionType::button || !m.inputTouchDirection.has_value() || m.inputTouchDirection == Direction::none)
+				if (region->type == +Ds4TouchRegionType::button || m.inputTouchDirection.value_or(Direction::none) == Direction::none)
 				{
 					const PressedState state1 = handleTouchToggle(m, modifier, region->state1);
 					applyMap(m, modifier, state1, Pressable::isActiveState(state1) ? 1.0f : 0.0f);

--- a/ds4wizard-cpp/InputSimulator.h
+++ b/ds4wizard-cpp/InputSimulator.h
@@ -42,6 +42,7 @@ class InputSimulator
 	std::shared_ptr<vigem::XInputTarget> xinputTarget;
 	XInputAxis_t simulatedXInputAxis = 0;
 
+	// TODO: refactor delta time to be the elapsed time of the last tick in seconds
 	Stopwatch deltaStopwatch {};
 	const float deltaTimeTarget = 1000.0f / 60.0f;
 	float deltaTime = 1.0f;
@@ -91,6 +92,8 @@ private:
 	 * \return \c true if overridden by a modifier.
 	 */
 	bool isOverriddenByModifierSet(const InputMapBase& map);
+
+	[[nodiscard]] float getAxisWithDeadZone(Ds4Axes_t axes, const InputAxisOptions& options) const;
 
 	/**
 	 * \brief Runs an input map with an optional parent modifier.

--- a/ds4wizard-cpp/InputSimulator.h
+++ b/ds4wizard-cpp/InputSimulator.h
@@ -93,7 +93,13 @@ private:
 	 */
 	bool isOverriddenByModifierSet(const InputMapBase& map);
 
-	[[nodiscard]] float getAxisWithDeadZone(Ds4Axes_t axes, const InputAxisOptions& options) const;
+	/**
+	 * \brief Given an axis, get the associated stick vector if applicable, and apply axis options.
+	 * \param axes The axes for the stick whose vector will be used.
+	 * \param options The options for the axis.
+	 * \return The value of the axis specified by \p axes with dead zone applied according to \p options.
+	 */
+	[[nodiscard]] float getAxisWithOptionsApplied(Ds4Axes_t axes, const InputAxisOptions& options) const;
 
 	/**
 	 * \brief Runs an input map with an optional parent modifier.
@@ -117,7 +123,7 @@ private:
 	 * \param pressable The pressable state of the touch region.
 	 * \return The simulated pressed state.
 	 */
-	static PressedState handleTouchToggle(const InputMap& m, InputModifier const* modifier, const Pressable& pressable);
+	static PressedState getTouchRegionPressedState(const InputMap& m, InputModifier const* modifier, const Pressable& pressable);
 
 	/**
 	 * \brief Applies a map's state as determined by \sa runMap

--- a/ds4wizard-cpp/Trackball.cpp
+++ b/ds4wizard-cpp/Trackball.cpp
@@ -111,7 +111,7 @@ TrackballSimulator::TrackballState TrackballSimulator::applyDirectionalForce(boo
 
 	const auto currentDirection = velocity.normalized();
 
-	if (!targetDirection.is_normalized())
+	if (!targetDirection.isNormalized())
 	{
 		targetDirection.normalize();
 	}
@@ -180,7 +180,7 @@ void TrackballSimulator::slow(float deltaTime)
 	const Vector2 direction = velocity.normalized();
 	const Vector2 changed = velocity - (direction * m);
 
-	if (velocity.length_squared() - changed.length_squared() < 0.0f)
+	if (velocity.lengthSquared() - changed.lengthSquared() < 0.0f)
 	{
 		velocity = Vector2::zero;
 	}
@@ -198,7 +198,7 @@ void TrackballSimulator::decelerate(float deltaTime)
 	const Vector2 direction = velocity.normalized();
 	const Vector2 changed = velocity - (direction * m);
 
-	if (velocity.length_squared() - changed.length_squared() < 0.0f)
+	if (velocity.lengthSquared() - changed.lengthSquared() < 0.0f)
 	{
 		velocity = Vector2::zero;
 	}

--- a/ds4wizard-cpp/Vector2.cpp
+++ b/ds4wizard-cpp/Vector2.cpp
@@ -177,14 +177,14 @@ Vector2::operator const float*() const
 	return array;
 }
 
-float Vector2::length_squared() const
+float Vector2::lengthSquared() const
 {
 	return x * x + y * y;
 }
 
 float Vector2::length() const
 {
-	return sqrt(length_squared());
+	return sqrt(lengthSquared());
 }
 
 void Vector2::normalize()
@@ -211,7 +211,7 @@ Vector2 Vector2::normalized() const
 
 bool Vector2::operator==(const Vector2& rhs) const
 {
-	return x == rhs.x && y == rhs.y;
+	return nearEqual(rhs);
 }
 
 bool Vector2::operator!=(const Vector2& rhs) const
@@ -219,9 +219,9 @@ bool Vector2::operator!=(const Vector2& rhs) const
 	return !(*this == rhs);
 }
 
-bool Vector2::is_normalized() const
+bool Vector2::isNormalized() const
 {
-	return gmath::is_one(length_squared());
+	return gmath::is_one(lengthSquared());
 }
 
 float Vector2::dot(const Vector2& rhs) const
@@ -229,14 +229,19 @@ float Vector2::dot(const Vector2& rhs) const
 	return (x * rhs.x) + (y * rhs.y);
 }
 
-bool Vector2::near_equal(const Vector2& rhs) const
+bool Vector2::nearEqual(const Vector2& rhs) const
 {
-	return gmath::near_equal(x, rhs.x) && gmath::near_equal(y, rhs.y);
+	return gmath::near_equal(x, rhs.x) &&
+	       gmath::near_equal(y, rhs.y);
 }
 
 Vector2 Vector2::lerp(const Vector2& start, const Vector2& end, float amount)
 {
-	return { gmath::lerp(start.x, end.x, amount), gmath::lerp(start.y, end.y, amount) };
+	return
+	{
+		gmath::lerp(start.x, end.x, amount),
+		gmath::lerp(start.y, end.y, amount)
+	};
 }
 
 Vector2 Vector2::clamp(const Vector2& v, float lower, float upper)

--- a/ds4wizard-cpp/Vector2.h
+++ b/ds4wizard-cpp/Vector2.h
@@ -51,16 +51,16 @@ public:
 	explicit operator float*();
 	explicit operator const float*() const;
 
-	float length_squared() const;
-	float length() const;
+	[[nodiscard]] float lengthSquared() const;
+	[[nodiscard]] float length() const;
 	void normalize();
-	Vector2 normalized() const;
+	[[nodiscard]] Vector2 normalized() const;
 	bool operator==(const Vector2& rhs) const;
 	bool operator!=(const Vector2& rhs) const;
-	bool is_normalized() const;
+	[[nodiscard]] bool isNormalized() const;
 
-	float dot(const Vector2& rhs) const;
-	bool near_equal(const Vector2& rhs) const;
+	[[nodiscard]] float dot(const Vector2& rhs) const;
+	[[nodiscard]] bool nearEqual(const Vector2& rhs) const;
 
 	static Vector2 lerp(const Vector2& start, const Vector2& end, float amount);
 	static Vector2 clamp(const Vector2& v, float lower, float upper);

--- a/ds4wizard-cpp/Vector3.cpp
+++ b/ds4wizard-cpp/Vector3.cpp
@@ -1,0 +1,283 @@
+#include "pch.h"
+#include "Vector3.h"
+#include "gmath.h"
+
+const Vector3 Vector3::zero = { 0.0f, 0.0f, 0.0f };
+const Vector3 Vector3::one  = { 1.0f, 1.0f, 1.0f };
+
+Vector3::Vector3(float f)  // NOLINT(cppcoreguidelines-pro-type-member-init, hicpp-member-init)
+	: x(f),
+	  y(f),
+	  z(f)
+{
+}
+
+Vector3::Vector3(float x, float y, float z)  // NOLINT(cppcoreguidelines-pro-type-member-init, hicpp-member-init)
+	: x(x),
+	  y(y),
+	  z(z)
+{
+}
+
+float Vector3::operator[](size_t i) const
+{
+	if (i >= 3)
+	{
+		throw;
+	}
+
+	return array[i];
+}
+
+Vector3 Vector3::operator+() const
+{
+	const Vector3 result = { +x, +y, +z };
+	return result;
+}
+
+Vector3 Vector3::operator-() const
+{
+	const Vector3 result = { -x, -y, -z };
+	return result;
+}
+
+Vector3 Vector3::operator+(const Vector3& rhs) const
+{
+	const Vector3 result = {
+		x + rhs.x,
+		y + rhs.y,
+		z + rhs.z
+	};
+
+	return result;
+}
+
+Vector3 Vector3::operator-(const Vector3& rhs) const
+{
+	const Vector3 result = {
+		x - rhs.x,
+		y - rhs.y,
+		z - rhs.z
+	};
+
+	return result;
+}
+
+Vector3 Vector3::operator*(const Vector3& rhs) const
+{
+	const Vector3 result = {
+		x * rhs.x,
+		y * rhs.y,
+		z * rhs.z
+	};
+
+	return result;
+}
+
+Vector3 Vector3::operator/(const Vector3& rhs) const
+{
+	const Vector3 result = {
+		x / rhs.x,
+		y / rhs.y,
+		z / rhs.z
+	};
+
+	return result;
+}
+
+void Vector3::operator+=(const Vector3& rhs)
+{
+	x += rhs.x;
+	y += rhs.y;
+	z += rhs.z;
+}
+
+void Vector3::operator-=(const Vector3& rhs)
+{
+	x -= rhs.x;
+	y -= rhs.y;
+	z -= rhs.z;
+}
+
+void Vector3::operator/=(const Vector3& rhs)
+{
+	x /= rhs.x;
+	y /= rhs.y;
+	z /= rhs.z;
+}
+
+void Vector3::operator*=(const Vector3& rhs)
+{
+	x *= rhs.x;
+	y *= rhs.y;
+	z *= rhs.z;
+}
+
+Vector3 Vector3::operator+(const float rhs) const
+{
+	const Vector3 result = {
+		x + rhs,
+		y + rhs,
+		z + rhs
+	};
+
+	return result;
+}
+
+Vector3 Vector3::operator-(const float rhs) const
+{
+	const Vector3 result = {
+		x - rhs,
+		y - rhs,
+		z - rhs
+	};
+
+	return result;
+}
+
+Vector3 Vector3::operator*(const float rhs) const
+{
+	const Vector3 result = {
+		x * rhs,
+		y * rhs,
+		z * rhs
+	};
+
+	return result;
+}
+
+Vector3 Vector3::operator/(const float rhs) const
+{
+	const Vector3 result = {
+		x / rhs,
+		y / rhs,
+		z / rhs
+	};
+
+	return result;
+}
+
+void Vector3::operator+=(const float rhs)
+{
+	x += rhs;
+	y += rhs;
+	z += rhs;
+}
+
+void Vector3::operator-=(const float rhs)
+{
+	x -= rhs;
+	y -= rhs;
+	z -= rhs;
+}
+
+void Vector3::operator/=(const float rhs)
+{
+	x /= rhs;
+	y /= rhs;
+	z /= rhs;
+}
+
+void Vector3::operator*=(const float rhs)
+{
+	x *= rhs;
+	y *= rhs;
+	z *= rhs;
+}
+
+Vector3::operator float*()
+{
+	return array;
+}
+
+Vector3::operator const float*() const
+{
+	return array;
+}
+
+float Vector3::lengthSquared() const
+{
+	return x * x + y * y + z * z;
+}
+
+float Vector3::length() const
+{
+	return sqrt(lengthSquared());
+}
+
+void Vector3::normalize()
+{
+	const auto l = length();
+
+	if (l == 0.0f)
+	{
+		x = y = z = 0.0f;
+	}
+	else
+	{
+		x = x / l;
+		y = y / l;
+		z = z / l;
+	}
+}
+
+Vector3 Vector3::normalized() const
+{
+	Vector3 result = *this;
+	result.normalize();
+	return result;
+}
+
+bool Vector3::operator==(const Vector3& rhs) const
+{
+	return gmath::near_equal(x, rhs.x) &&
+	       gmath::near_equal(y, rhs.y) &&
+	       gmath::near_equal(z, rhs.z);
+}
+
+bool Vector3::operator!=(const Vector3& rhs) const
+{
+	return !(*this == rhs);
+}
+
+bool Vector3::isNormalized() const
+{
+	return gmath::is_one(lengthSquared());
+}
+
+float Vector3::dot(const Vector3& rhs) const
+{
+	return (x * rhs.x) + (y * rhs.y) + (z * rhs.z);
+}
+
+bool Vector3::nearEqual(const Vector3& rhs) const
+{
+	return gmath::near_equal(x, rhs.x) &&
+	       gmath::near_equal(y, rhs.y) &&
+	       gmath::near_equal(z, rhs.z);
+}
+
+Vector3 Vector3::lerp(const Vector3& start, const Vector3& end, float amount)
+{
+	return
+	{
+		gmath::lerp(start.x, end.x, amount),
+		gmath::lerp(start.y, end.y, amount),
+		gmath::lerp(start.z, end.z, amount)
+	};
+}
+
+Vector3 Vector3::clamp(const Vector3& v, float lower, float upper)
+{
+	return
+	{
+		std::clamp(v.x, lower, upper),
+		std::clamp(v.y, lower, upper),
+		std::clamp(v.z, lower, upper)
+	};
+}
+
+Vector3 operator*(float lhs, const Vector3& rhs)
+{
+	return rhs * lhs;
+}

--- a/ds4wizard-cpp/Vector3.h
+++ b/ds4wizard-cpp/Vector3.h
@@ -1,0 +1,69 @@
+#pragma once
+
+class Vector3
+{
+public:
+	static const Vector3 zero;
+	static const Vector3 one;
+
+	union
+	{
+	#pragma pack(push, 1)
+		struct
+		{
+			float x, y, z;
+		};
+
+		float array[3];
+	#pragma pack(pop)
+	};
+
+	Vector3() = default;
+	Vector3(float x, float y, float z);
+
+	explicit Vector3(float f);
+
+	float operator[](size_t i) const;
+
+	Vector3 operator+() const;
+	Vector3 operator-() const;
+
+	Vector3 operator+(const Vector3& rhs) const;
+	Vector3 operator-(const Vector3& rhs) const;
+	Vector3 operator*(const Vector3& rhs) const;
+	Vector3 operator/(const Vector3& rhs) const;
+
+	void operator+=(const Vector3& rhs);
+	void operator-=(const Vector3& rhs);
+	void operator/=(const Vector3& rhs);
+	void operator*=(const Vector3& rhs);
+
+	Vector3 operator+(float rhs) const;
+	Vector3 operator-(float rhs) const;
+	Vector3 operator*(float rhs) const;
+	Vector3 operator/(float rhs) const;
+
+	void operator+=(float rhs);
+	void operator-=(float rhs);
+	void operator/=(float rhs);
+	void operator*=(float rhs);
+
+	explicit operator float*();
+	explicit operator const float*() const;
+
+	[[nodiscard]] float lengthSquared() const;
+	[[nodiscard]] float length() const;
+	void normalize();
+	[[nodiscard]] Vector3 normalized() const;
+	bool operator==(const Vector3& rhs) const;
+	bool operator!=(const Vector3& rhs) const;
+	[[nodiscard]] bool isNormalized() const;
+
+	[[nodiscard]] float dot(const Vector3& rhs) const;
+	[[nodiscard]] bool nearEqual(const Vector3& rhs) const;
+
+	static Vector3 lerp(const Vector3& start, const Vector3& end, float amount);
+	static Vector3 clamp(const Vector3& v, float lower, float upper);
+};
+
+Vector3 operator*(float lhs, const Vector3& rhs);

--- a/ds4wizard-cpp/ds4wizard-cpp.vcxproj
+++ b/ds4wizard-cpp/ds4wizard-cpp.vcxproj
@@ -214,6 +214,7 @@ copy "$(SolutionDir)bin\$(Configuration)\$(PlatformShortName)\*" "$(SolutionDir)
     <ClCompile Include="stringutil.cpp" />
     <ClCompile Include="Trackball.cpp" />
     <ClCompile Include="Vector2.cpp" />
+    <ClCompile Include="Vector3.cpp" />
     <ClCompile Include="ViGEmDriver.cpp" />
     <ClCompile Include="ViGEmTarget.cpp" />
     <ClCompile Include="XInputGamepad.cpp" />
@@ -229,6 +230,7 @@ copy "$(SolutionDir)bin\$(Configuration)\$(PlatformShortName)\*" "$(SolutionDir)
     <ClInclude Include="DeviceProfile.h" />
     <ClInclude Include="DeviceProfileCache.h" />
     <ClInclude Include="RumbleSequence.h" />
+    <ClInclude Include="Vector3.h" />
     <ClInclude Include="XInputRumbleSimulator.h" />
     <QtMoc Include="DevicePropertiesDialog.h">
     </QtMoc>

--- a/ds4wizard-cpp/ds4wizard-cpp.vcxproj.filters
+++ b/ds4wizard-cpp/ds4wizard-cpp.vcxproj.filters
@@ -136,6 +136,9 @@
     <ClCompile Include="RumbleSequence.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="Vector3.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Resource Files">
@@ -323,6 +326,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="RumbleSequence.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="Vector3.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/ds4wizard-cpp/enums.cpp
+++ b/ds4wizard-cpp/enums.cpp
@@ -282,6 +282,51 @@ static const char* Ds4Axes_names[] = {
 	"gyroZ"
 };
 
+Ds4Axes_t Ds4Axes::expand(Ds4Axes_t axes)
+{
+	Ds4Axes_t result = axes;
+	
+	if (axes & leftStick)
+	{
+		result |= leftStick;
+	}
+
+	if (axes & rightStick)
+	{
+		result |= rightStick;
+	}
+
+	if (axes & gyroscope)
+	{
+		result |= gyroscope;
+	}
+
+	if (axes & accelerometer)
+	{
+		result |= accelerometer;
+	}
+
+	return result;
+}
+
+size_t Ds4Axes::componentCount(Ds4Axes_t vector_axis)
+{
+	if (vector_axis & (leftStick | rightStick))
+	{
+		// left/right stick have components x, y
+		return 2;
+	}
+
+	if (vector_axis & (gyroscope | accelerometer))
+	{
+		// gyroscope/accelerometer have components x, y, z
+		return 3;
+	}
+
+	// everything else is 1
+	return 1;
+}
+
 SERIALIZE_DEF(Ds4Axes)
 
 const std::array<Ds4Extensions_t, 4> Ds4Extensions_values = {

--- a/ds4wizard-cpp/enums.h
+++ b/ds4wizard-cpp/enums.h
@@ -20,19 +20,21 @@ BETTER_ENUM(AxisPolarity, int,
             negative)
 
 /**
- * \brief Configuration for axis dead zone scaling.
+ * \brief Configuration for the source of the value used in dead zone calculations.
  */
-BETTER_ENUM(DeadZoneMode, int,
+BETTER_ENUM(DeadZoneSource, int,
             /** \brief No dead zone is applied. */
             none,
-            /** \brief When an axis reaches the dead zone threshold, the raw value is let through. */
-            hardLimit,
-            /**
-             * \brief
-             * When the dead zone threshold is reached, the axis output is scaled relative to that threshold (normalized).
-             * Example: if the dead zone is 0.2 and an axis reaches or exceeds that value, it will be normalized to [0.0 .. 1.0].
+
+            /** \brief Use the magnitude of the vector that the input belongs to.
+             *
+             * e.g. If the left stick is the input, the magnitude of the left stick's
+             * X and Y values must exceed the dead zone value to activate.
              */
-            scale)
+            axisVectorMagnitude,
+
+            /** \brief Use the value of the axis as-is, accounting for polarity/direction. */
+            axisValue)
 
 // TODO: /!\ better name
 BETTER_ENUM(SimulatorType, int, none, input, action)
@@ -319,6 +321,21 @@ struct Ds4Axes
 	static const Ds4Axes_t rightStick    = rightStickX | rightStickY;
 	static const Ds4Axes_t accelerometer = accelX | accelY | accelZ;
 	static const Ds4Axes_t gyroscope     = gyroX | gyroY | gyroZ;
+
+	/**
+	 * \brief Given any combination of \c Ds4Axes bits, returns a
+	 * bitmask expanded to cover all vector components of the axes.
+	 * \param axes The axes to expand.
+	 * \return The bitmask for expanded axes.
+	 */
+	static Ds4Axes_t expand(Ds4Axes_t axes);
+
+	/**
+	 * \brief Given an axis, returns the number of components in the vector it belongs to.
+	 * \param vector_axis The axis to retrieve the vector component count of.
+	 * \return The number of components in the axis vector.
+	 */
+	static size_t componentCount(Ds4Axes_t vector_axis);
 };
 
 ENUM_FLAGS(Ds4Axes);

--- a/ds4wizard-cpp/pch.h
+++ b/ds4wizard-cpp/pch.h
@@ -104,4 +104,5 @@
 #include "stringutil.h"
 #include "Trackball.h"
 #include "Vector2.h"
+#include "Vector3.h"
 #include "XInputGamepad.h"


### PR DESCRIPTION
Fixes issue #1

* Adds field `deadZoneSource` to `InputAxisOptions` which can have a value of:
  * `axisVectorMagnitude` - new, default behavior
  * `axisValue` - old behavior